### PR TITLE
Fix dev tool panel mobile: add controls min-height and fix log scrolling

### DIFF
--- a/docs/src/app/globals.scss
+++ b/docs/src/app/globals.scss
@@ -1567,7 +1567,12 @@ button {
 
   .toolbar-options {
     width: 100%;
+    min-height: 120px;
     max-height: 150px;
+  }
+
+  .toolbar-log-viewer {
+    min-height: 0;
   }
 
   .toolbar-divider {


### PR DESCRIPTION
The options panel on mobile had no min-height, making controls barely
visible. The log viewer was not scrollable because the flex child lacked
min-height: 0, preventing overflow-y: auto from activating.

https://claude.ai/code/session_01EC7E33qiiE6DjfW18nAqoh