### PR TITLE
fix: add bin field to agent-tail umbrella package

### DIFF
--- a/packages/agent-tail/package.json
+++ b/packages/agent-tail/package.json
@@ -77,5 +77,8 @@
         "next": "^15.0.0",
         "react": "^19.0.0",
         "@types/react": "^19.0.0"
+    },
+    "bin": {
+        "agent-tail": "node_modules/agent-tail-core/dist/cli.mjs"
     }
 }


### PR DESCRIPTION
## Problem

Running `npx agent-tail` or `bunx agent-tail` fails on some machines with:

```
error: could not determine executable to run for package agent-tail
```

## Cause

The `agent-tail` package (umbrella package in `packages/agent-tail`) does not declare a `bin` field in its `package.json`. The actual CLI lives in `agent-tail-core`, which correctly has `bin: { "agent-tail": "./dist/cli.mjs" }`. When you run `npx agent-tail`, the package manager looks for a bin on the `agent-tail` package itself and finds none.

## Fix

Add a `bin` field that delegates to `agent-tail-core`:

```json
"bin": {
    "agent-tail": "node_modules/agent-tail-core/dist/cli.mjs"
}
```

This ensures `npx agent-tail` works consistently across npm, pnpm, yarn, and bun.

Fixes #3

Made with [Cursor](https://cursor.com)