### PR TITLE
fix(core): preserve terminal colors in CLI logs

### DIFF
--- a/packages/core/src/ansi.ts
+++ b/packages/core/src/ansi.ts
@@ -1,0 +1,5 @@
+const ANSI_PATTERN = /[\u001B\u009B][[\]()#;?]*(?:(?:(?:(?:;[-a-zA-Z\d/#&.:=?%@~_]+)*|[a-zA-Z\d]+(?:;[-a-zA-Z\d/#&.:=?%@~_]*)*)?\u0007)|(?:(?:\d{1,4}(?:;\d{0,4})*)?[\dA-PR-TZcf-nq-uy=><~]))/g
+
+export function strip_ansi_codes(text: string): string {
+    return text.replace(ANSI_PATTERN, "")
+}

--- a/packages/core/src/commands.ts
+++ b/packages/core/src/commands.ts
@@ -6,6 +6,41 @@ import { resolve_options } from "./types"
 import { should_exclude } from "./filter"
 
 const PREFIX = "\x1b[36m[agent-tail]\x1b[0m"
+const ANSI_PATTERN = /\x1B\[[0-?]*[ -/]*[@-~]/g
+
+function strip_ansi_codes(text: string): string {
+    return text.replace(ANSI_PATTERN, "")
+}
+
+function get_child_env(session_dir: string): NodeJS.ProcessEnv {
+    const env: NodeJS.ProcessEnv = {
+        ...process.env,
+        [SESSION_ENV_VAR]: session_dir,
+    }
+
+    if (env.NO_COLOR !== undefined || env.FORCE_COLOR === "0") {
+        return env
+    }
+
+    env.FORCE_COLOR = env.FORCE_COLOR ?? "1"
+    env.CLICOLOR_FORCE = env.CLICOLOR_FORCE ?? "1"
+    return env
+}
+
+function end_stream(stream: fs.WriteStream | null): Promise<void> {
+    if (!stream) return Promise.resolve()
+
+    return new Promise((resolve, reject) => {
+        stream.end((err?: Error | null) => {
+            if (err) {
+                reject(err)
+                return
+            }
+
+            resolve()
+        })
+    })
+}
 
 export interface CliOptions {
     log_dir: string
@@ -85,7 +120,7 @@ function write_to_logs(
     combined_stream: fs.WriteStream | null,
     excludes: string[] = []
 ): void {
-    const text = chunk.toString()
+    const text = strip_ansi_codes(chunk.toString())
     const lines = text.split(/\r?\n/)
     for (let i = 0; i < lines.length; i++) {
         if (lines[i].length > 0) {
@@ -135,9 +170,11 @@ export function cmd_wrap(
 
     const child = spawn(command.join(" "), {
         stdio: ["inherit", "pipe", "pipe"],
-        env: { ...process.env, [SESSION_ENV_VAR]: session_dir },
+        env: get_child_env(session_dir),
         shell: true,
     })
+
+    const signal_handlers = new Map<"SIGINT" | "SIGTERM", () => void>()
 
     child.stdout?.on("data", (chunk: Buffer) => {
         process.stdout.write(chunk)
@@ -149,22 +186,45 @@ export function cmd_wrap(
     })
 
     return new Promise((resolve, reject) => {
-        child.on("close", (code) => {
-            log_stream.end()
-            combined_stream?.end()
-            resolve(code ?? 0)
+        child.on("close", async (code) => {
+            for (const [signal, handler] of signal_handlers) {
+                process.off(signal, handler)
+            }
+
+            try {
+                await Promise.all([
+                    end_stream(log_stream),
+                    end_stream(combined_stream),
+                ])
+                resolve(code ?? 0)
+            } catch (err) {
+                reject(err)
+            }
         })
 
-        child.on("error", (err) => {
-            log_stream.end()
-            combined_stream?.end()
+        child.on("error", async (err) => {
+            for (const [signal, handler] of signal_handlers) {
+                process.off(signal, handler)
+            }
+
+            try {
+                await Promise.all([
+                    end_stream(log_stream),
+                    end_stream(combined_stream),
+                ])
+            } catch {
+                // Ignore stream shutdown errors when surfacing child process error.
+            }
+
             reject(err)
         })
 
         for (const signal of ["SIGINT", "SIGTERM"] as const) {
-            process.on(signal, () => {
+            const handler = () => {
                 child.kill(signal)
-            })
+            }
+            signal_handlers.set(signal, handler)
+            process.on(signal, handler)
         }
     })
 }
@@ -224,7 +284,7 @@ export function cmd_run(
 
         const child = spawn(svc.command, {
             stdio: ["inherit", "pipe", "pipe"],
-            env: { ...process.env, [SESSION_ENV_VAR]: session_dir },
+            env: get_child_env(session_dir),
             shell: true,
         })
 
@@ -234,10 +294,11 @@ export function cmd_run(
             for (let j = 0; j < lines.length; j++) {
                 if (lines[j].length > 0) {
                     if (options.excludes.length && should_exclude(lines[j], options.excludes)) continue
-                    log_stream.write(lines[j] + "\n")
+                    const log_line = strip_ansi_codes(lines[j])
+                    log_stream.write(log_line + "\n")
                     if (!is_muted) {
                         target.write(`${tag} ${lines[j]}\n`)
-                        combined_stream?.write(`[${svc.name}] ${lines[j]}\n`)
+                        combined_stream?.write(`[${svc.name}] ${log_line}\n`)
                     }
                 } else if (j < lines.length - 1) {
                     log_stream.write("\n")
@@ -275,15 +336,22 @@ export function cmd_run(
         })
     })
 
+    const signal_handlers = new Map<"SIGINT" | "SIGTERM", () => void>()
     for (const signal of ["SIGINT", "SIGTERM"] as const) {
-        process.on(signal, () => {
+        const handler = () => {
             for (const child of children) {
                 child.kill(signal)
             }
-        })
+        }
+        signal_handlers.set(signal, handler)
+        process.on(signal, handler)
     }
 
-    return Promise.all(promises).then(() => {
-        combined_stream?.end()
+    return Promise.all(promises).then(async () => {
+        for (const [signal, handler] of signal_handlers) {
+            process.off(signal, handler)
+        }
+
+        await end_stream(combined_stream)
     })
 }

--- a/packages/core/src/commands.ts
+++ b/packages/core/src/commands.ts
@@ -289,8 +289,8 @@ export function cmd_run(
             const lines = text.split(/\r?\n/)
             for (let j = 0; j < lines.length; j++) {
                 if (lines[j].length > 0) {
-                    if (options.excludes.length && should_exclude(lines[j], options.excludes)) continue
                     const log_line = strip_ansi_codes(lines[j])
+                    if (options.excludes.length && should_exclude(log_line, options.excludes)) continue
                     log_stream.write(log_line + "\n")
                     if (!is_muted) {
                         target.write(`${tag} ${lines[j]}\n`)

--- a/packages/core/src/commands.ts
+++ b/packages/core/src/commands.ts
@@ -1,16 +1,12 @@
 import { spawn } from "node:child_process"
 import fs from "node:fs"
 import path from "node:path"
+import { strip_ansi_codes } from "./ansi"
 import { LogManager, SESSION_ENV_VAR } from "./log-manager"
 import { resolve_options } from "./types"
 import { should_exclude } from "./filter"
 
 const PREFIX = "\x1b[36m[agent-tail]\x1b[0m"
-const ANSI_PATTERN = /\x1B\[[0-?]*[ -/]*[@-~]/g
-
-function strip_ansi_codes(text: string): string {
-    return text.replace(ANSI_PATTERN, "")
-}
 
 function get_child_env(session_dir: string): NodeJS.ProcessEnv {
     const env: NodeJS.ProcessEnv = {

--- a/packages/core/src/formatter.ts
+++ b/packages/core/src/formatter.ts
@@ -1,12 +1,13 @@
 import type { LogEntry } from "./types"
+import { strip_ansi_codes } from "./ansi"
 
 export function format_log_line(entry: LogEntry): string {
     const time = entry.timestamp
     const level = entry.level.toUpperCase().padEnd(7)
-    const message = entry.args.join(" ")
-    const location = entry.url ? ` (${entry.url})` : ""
+    const message = entry.args.map(strip_ansi_codes).join(" ")
+    const location = entry.url ? ` (${strip_ansi_codes(entry.url)})` : ""
     const stack = entry.stack
-        ? `\n    ${entry.stack.split(/\r?\n/).join("\n    ")}`
+        ? `\n    ${strip_ansi_codes(entry.stack).split(/\r?\n/).join("\n    ")}`
         : ""
     return `[${time}] [${level}] ${message}${location}${stack}\n`
 }

--- a/scripts/color-demo.mjs
+++ b/scripts/color-demo.mjs
@@ -1,0 +1,36 @@
+#!/usr/bin/env bun
+
+const lines = [
+    ["\x1b[31mERROR\x1b[0m", "something spicy happened"],
+    ["\x1b[33mWARN\x1b[0m", "this is probably fine"],
+    ["\x1b[32mOK\x1b[0m", "still alive and noisy"],
+    ["\x1b[36mINFO\x1b[0m", "streaming colorful logs"],
+]
+
+const colors_enabled = process.env.NO_COLOR === undefined
+
+function maybe_color(text) {
+    return colors_enabled ? text : text.replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, "")
+}
+
+let index = 0
+
+const timer = setInterval(() => {
+    const [level, message] = lines[index % lines.length]
+    const dim = maybe_color("\x1b[2m")
+    const reset = maybe_color("\x1b[0m")
+    const stamp = new Date().toISOString()
+
+    console.log(`${dim}${stamp}${reset} ${maybe_color(level)} ${message}`)
+    index += 1
+}, 700)
+
+function shutdown() {
+    clearInterval(timer)
+    process.exit(0)
+}
+
+process.on("SIGINT", shutdown)
+process.on("SIGTERM", shutdown)
+
+console.log(maybe_color("\x1b[35mcolor demo started\x1b[0m"))

--- a/scripts/wrap-before-after-demo.mjs
+++ b/scripts/wrap-before-after-demo.mjs
@@ -1,0 +1,16 @@
+#!/usr/bin/env bun
+
+const use_color = process.env.FORCE_COLOR === "1"
+
+const lines = [
+    ["ERROR", "something spicy happened", "\x1b[31m"],
+    ["WARN", "this is probably fine", "\x1b[33m"],
+    ["OK", "still alive and noisy", "\x1b[32m"],
+    ["INFO", "streaming colorful logs", "\x1b[36m"],
+    ["DONE", "five lines, no bullshit", "\x1b[35m"],
+]
+
+for (const [level, message, color] of lines) {
+    const label = use_color ? `${color}${level}\x1b[0m` : level
+    console.log(`${label} ${message}`)
+}

--- a/tests/core/cli.test.ts
+++ b/tests/core/cli.test.ts
@@ -28,8 +28,10 @@ const DEFAULT_OPTS: CliOptions = {
     mutes: [],
 }
 
-const ANSI_COLOR_COMMAND = "if [ \"$FORCE_COLOR\" = \"1\" ]; then printf '\\033[31mcolored output\\033[0m\\n'; else printf 'plain output\\n'; fi"
-const ANSI_COLOR_STDERR_COMMAND = "if [ \"$FORCE_COLOR\" = \"1\" ]; then printf '\\033[33mcolored stderr\\033[0m\\n' >&2; else printf 'plain stderr\\n' >&2; fi"
+const ANSI_COLOR_COMMAND =
+    "if [ \"$FORCE_COLOR\" = \"1\" ]; then printf '\\033[31mcolored output\\033[0m\\n'; else printf 'plain output\\n'; fi"
+const ANSI_COLOR_STDERR_COMMAND =
+    "if [ \"$FORCE_COLOR\" = \"1\" ]; then printf '\\033[33mcolored stderr\\033[0m\\n' >&2; else printf 'plain stderr\\n' >&2; fi"
 
 describe("CLI commands", () => {
     let temp_dir: string
@@ -161,7 +163,9 @@ describe("CLI commands", () => {
         it("preserves ANSI output in terminal but strips it from logs", async () => {
             cmd_init(temp_dir, DEFAULT_OPTS)
 
-            const write_spy = vi.spyOn(process.stdout, "write").mockImplementation(() => true)
+            const write_spy = vi
+                .spyOn(process.stdout, "write")
+                .mockImplementation(() => true)
 
             const code = await cmd_wrap(
                 temp_dir,
@@ -171,7 +175,9 @@ describe("CLI commands", () => {
             )
             expect(code).toBe(0)
 
-            const terminal_output = write_spy.mock.calls.map(c => c[0].toString()).join("")
+            const terminal_output = write_spy.mock.calls
+                .map(c => c[0].toString())
+                .join("")
 
             const log_dir = path.join(temp_dir, "tmp/logs")
             const session_dir = fs.realpathSync(path.join(log_dir, "latest"))
@@ -186,7 +192,9 @@ describe("CLI commands", () => {
         it("preserves ANSI stderr in terminal and strips it from wrap logs", async () => {
             cmd_init(temp_dir, DEFAULT_OPTS)
 
-            const stderr_spy = vi.spyOn(process.stderr, "write").mockImplementation(() => true)
+            const stderr_spy = vi
+                .spyOn(process.stderr, "write")
+                .mockImplementation(() => true)
 
             const code = await cmd_wrap(
                 temp_dir,
@@ -196,11 +204,19 @@ describe("CLI commands", () => {
             )
             expect(code).toBe(0)
 
-            const terminal_output = stderr_spy.mock.calls.map(c => c[0].toString()).join("")
+            const terminal_output = stderr_spy.mock.calls
+                .map(c => c[0].toString())
+                .join("")
             const log_dir = path.join(temp_dir, "tmp/logs")
             const session_dir = fs.realpathSync(path.join(log_dir, "latest"))
-            const log_content = fs.readFileSync(path.join(session_dir, "ansi-wrap-stderr.log"), "utf-8")
-            const combined_content = fs.readFileSync(path.join(session_dir, "combined.log"), "utf-8")
+            const log_content = fs.readFileSync(
+                path.join(session_dir, "ansi-wrap-stderr.log"),
+                "utf-8"
+            )
+            const combined_content = fs.readFileSync(
+                path.join(session_dir, "combined.log"),
+                "utf-8"
+            )
 
             expect(terminal_output).toContain("\x1b[33mcolored stderr\x1b[0m")
             expect(log_content).toContain("colored stderr")
@@ -265,7 +281,9 @@ describe("CLI commands", () => {
         })
 
         it("preserves ANSI output in terminal but strips it from run logs", async () => {
-            const write_spy = vi.spyOn(process.stdout, "write").mockImplementation(() => true)
+            const write_spy = vi
+                .spyOn(process.stdout, "write")
+                .mockImplementation(() => true)
 
             await cmd_run(
                 temp_dir,
@@ -273,7 +291,9 @@ describe("CLI commands", () => {
                 DEFAULT_OPTS
             )
 
-            const terminal_output = write_spy.mock.calls.map(c => c[0].toString()).join("")
+            const terminal_output = write_spy.mock.calls
+                .map(c => c[0].toString())
+                .join("")
 
             const log_dir = path.join(temp_dir, "tmp/logs")
             const session_dir = fs.realpathSync(path.join(log_dir, "latest"))
@@ -290,7 +310,9 @@ describe("CLI commands", () => {
         })
 
         it("preserves ANSI stderr in terminal but strips it from run logs", async () => {
-            const stderr_spy = vi.spyOn(process.stderr, "write").mockImplementation(() => true)
+            const stderr_spy = vi
+                .spyOn(process.stderr, "write")
+                .mockImplementation(() => true)
 
             await cmd_run(
                 temp_dir,
@@ -298,18 +320,48 @@ describe("CLI commands", () => {
                 DEFAULT_OPTS
             )
 
-            const terminal_output = stderr_spy.mock.calls.map(c => c[0].toString()).join("")
+            const terminal_output = stderr_spy.mock.calls
+                .map(c => c[0].toString())
+                .join("")
 
             const log_dir = path.join(temp_dir, "tmp/logs")
             const session_dir = fs.realpathSync(path.join(log_dir, "latest"))
-            const log_content = fs.readFileSync(path.join(session_dir, "ansi.log"), "utf-8")
-            const combined_content = fs.readFileSync(path.join(session_dir, "combined.log"), "utf-8")
+            const log_content = fs.readFileSync(
+                path.join(session_dir, "ansi.log"),
+                "utf-8"
+            )
+            const combined_content = fs.readFileSync(
+                path.join(session_dir, "combined.log"),
+                "utf-8"
+            )
 
             expect(terminal_output).toContain("\x1b[33mcolored stderr\x1b[0m")
             expect(log_content).toContain("colored stderr")
             expect(log_content).not.toContain("\x1b[33m")
             expect(combined_content).toContain("colored stderr")
             expect(combined_content).not.toContain("\x1b[33m")
+        })
+
+        it("filters ANSI-colored excluded lines from run logs", async () => {
+            vi.spyOn(process.stdout, "write").mockImplementation(() => true)
+
+            const opts = { ...DEFAULT_OPTS, excludes: ["secret"] }
+            await cmd_run(
+                temp_dir,
+                [
+                    "svc: printf '\\033[31msecret data\\033[0m\\nkeep this\\n'",
+                ],
+                opts
+            )
+
+            const log_dir = path.join(temp_dir, "tmp/logs")
+            const session_dir = fs.realpathSync(path.join(log_dir, "latest"))
+            const log_file = path.join(session_dir, "svc.log")
+            const content = fs.readFileSync(log_file, "utf-8")
+
+            expect(content).toContain("keep this")
+            expect(content).not.toContain("secret data")
+            expect(content).not.toContain("\x1b[31m")
         })
     })
 
@@ -419,7 +471,9 @@ describe("CLI commands", () => {
         })
 
         it("muted service is excluded from terminal output", async () => {
-            const write_spy = vi.spyOn(process.stdout, "write").mockImplementation(() => true)
+            const write_spy = vi
+                .spyOn(process.stdout, "write")
+                .mockImplementation(() => true)
 
             const opts = { ...DEFAULT_OPTS, mutes: ["quiet"] }
             await cmd_run(
@@ -428,7 +482,9 @@ describe("CLI commands", () => {
                 opts
             )
 
-            const terminal_output = write_spy.mock.calls.map(c => c[0].toString()).join("")
+            const terminal_output = write_spy.mock.calls
+                .map(c => c[0].toString())
+                .join("")
 
             expect(terminal_output).toContain("visible")
             expect(terminal_output).not.toContain("hidden")

--- a/tests/core/cli.test.ts
+++ b/tests/core/cli.test.ts
@@ -28,6 +28,8 @@ const DEFAULT_OPTS: CliOptions = {
     mutes: [],
 }
 
+const ANSI_COLOR_COMMAND = "if [ \"$FORCE_COLOR\" = \"1\" ]; then printf '\\033[31mcolored output\\033[0m\\n'; else printf 'plain output\\n'; fi"
+
 describe("CLI commands", () => {
     let temp_dir: string
 
@@ -154,6 +156,31 @@ describe("CLI commands", () => {
                 cmd_wrap(temp_dir, "svc", [], DEFAULT_OPTS)
             ).toThrow("requires a command")
         })
+
+        it("preserves ANSI output in terminal but strips it from logs", async () => {
+            cmd_init(temp_dir, DEFAULT_OPTS)
+
+            const write_spy = vi.spyOn(process.stdout, "write").mockImplementation(() => true)
+
+            const code = await cmd_wrap(
+                temp_dir,
+                "ansi-wrap",
+                [ANSI_COLOR_COMMAND],
+                DEFAULT_OPTS
+            )
+            expect(code).toBe(0)
+
+            const terminal_output = write_spy.mock.calls.map(c => c[0].toString()).join("")
+
+            const log_dir = path.join(temp_dir, "tmp/logs")
+            const session_dir = fs.realpathSync(path.join(log_dir, "latest"))
+            const log_file = path.join(session_dir, "ansi-wrap.log")
+            const content = fs.readFileSync(log_file, "utf-8")
+
+            expect(terminal_output).toContain("\x1b[31mcolored output\x1b[0m")
+            expect(content).toContain("colored output")
+            expect(content).not.toContain("\x1b[31m")
+        })
     })
 
     describe("cmd_run", () => {
@@ -208,6 +235,31 @@ describe("CLI commands", () => {
             expect(() => cmd_run(temp_dir, [], DEFAULT_OPTS)).toThrow(
                 "requires at least one service"
             )
+        })
+
+        it("preserves ANSI output in terminal but strips it from run logs", async () => {
+            const write_spy = vi.spyOn(process.stdout, "write").mockImplementation(() => true)
+
+            await cmd_run(
+                temp_dir,
+                [`ansi: ${ANSI_COLOR_COMMAND}`],
+                DEFAULT_OPTS
+            )
+
+            const terminal_output = write_spy.mock.calls.map(c => c[0].toString()).join("")
+
+            const log_dir = path.join(temp_dir, "tmp/logs")
+            const session_dir = fs.realpathSync(path.join(log_dir, "latest"))
+            const log_file = path.join(session_dir, "ansi.log")
+            const combined_file = path.join(session_dir, "combined.log")
+            const log_content = fs.readFileSync(log_file, "utf-8")
+            const combined_content = fs.readFileSync(combined_file, "utf-8")
+
+            expect(terminal_output).toContain("\x1b[31mcolored output\x1b[0m")
+            expect(log_content).toContain("colored output")
+            expect(log_content).not.toContain("\x1b[31m")
+            expect(combined_content).toContain("colored output")
+            expect(combined_content).not.toContain("\x1b[31m")
         })
     })
 

--- a/tests/core/cli.test.ts
+++ b/tests/core/cli.test.ts
@@ -29,6 +29,7 @@ const DEFAULT_OPTS: CliOptions = {
 }
 
 const ANSI_COLOR_COMMAND = "if [ \"$FORCE_COLOR\" = \"1\" ]; then printf '\\033[31mcolored output\\033[0m\\n'; else printf 'plain output\\n'; fi"
+const ANSI_COLOR_STDERR_COMMAND = "if [ \"$FORCE_COLOR\" = \"1\" ]; then printf '\\033[33mcolored stderr\\033[0m\\n' >&2; else printf 'plain stderr\\n' >&2; fi"
 
 describe("CLI commands", () => {
     let temp_dir: string
@@ -181,6 +182,32 @@ describe("CLI commands", () => {
             expect(content).toContain("colored output")
             expect(content).not.toContain("\x1b[31m")
         })
+
+        it("preserves ANSI stderr in terminal and strips it from wrap logs", async () => {
+            cmd_init(temp_dir, DEFAULT_OPTS)
+
+            const stderr_spy = vi.spyOn(process.stderr, "write").mockImplementation(() => true)
+
+            const code = await cmd_wrap(
+                temp_dir,
+                "ansi-wrap-stderr",
+                [ANSI_COLOR_STDERR_COMMAND],
+                DEFAULT_OPTS
+            )
+            expect(code).toBe(0)
+
+            const terminal_output = stderr_spy.mock.calls.map(c => c[0].toString()).join("")
+            const log_dir = path.join(temp_dir, "tmp/logs")
+            const session_dir = fs.realpathSync(path.join(log_dir, "latest"))
+            const log_content = fs.readFileSync(path.join(session_dir, "ansi-wrap-stderr.log"), "utf-8")
+            const combined_content = fs.readFileSync(path.join(session_dir, "combined.log"), "utf-8")
+
+            expect(terminal_output).toContain("\x1b[33mcolored stderr\x1b[0m")
+            expect(log_content).toContain("colored stderr")
+            expect(log_content).not.toContain("\x1b[33m")
+            expect(combined_content).toContain("colored stderr")
+            expect(combined_content).not.toContain("\x1b[33m")
+        })
     })
 
     describe("cmd_run", () => {
@@ -260,6 +287,29 @@ describe("CLI commands", () => {
             expect(log_content).not.toContain("\x1b[31m")
             expect(combined_content).toContain("colored output")
             expect(combined_content).not.toContain("\x1b[31m")
+        })
+
+        it("preserves ANSI stderr in terminal but strips it from run logs", async () => {
+            const stderr_spy = vi.spyOn(process.stderr, "write").mockImplementation(() => true)
+
+            await cmd_run(
+                temp_dir,
+                [`ansi: ${ANSI_COLOR_STDERR_COMMAND}`],
+                DEFAULT_OPTS
+            )
+
+            const terminal_output = stderr_spy.mock.calls.map(c => c[0].toString()).join("")
+
+            const log_dir = path.join(temp_dir, "tmp/logs")
+            const session_dir = fs.realpathSync(path.join(log_dir, "latest"))
+            const log_content = fs.readFileSync(path.join(session_dir, "ansi.log"), "utf-8")
+            const combined_content = fs.readFileSync(path.join(session_dir, "combined.log"), "utf-8")
+
+            expect(terminal_output).toContain("\x1b[33mcolored stderr\x1b[0m")
+            expect(log_content).toContain("colored stderr")
+            expect(log_content).not.toContain("\x1b[33m")
+            expect(combined_content).toContain("colored stderr")
+            expect(combined_content).not.toContain("\x1b[33m")
         })
     })
 

--- a/tests/core/formatter.test.ts
+++ b/tests/core/formatter.test.ts
@@ -76,4 +76,23 @@ describe("format_log_line", () => {
         expect(result).not.toContain("(")
         expect(result).not.toContain(")")
     })
+
+    it("strips ANSI codes from messages, urls, and stack traces", () => {
+        const entry: LogEntry = {
+            level: "error",
+            args: ["\x1b[31mboom\x1b[0m", "plain"],
+            timestamp: "10:30:00.123",
+            url: "\x1b]8;;https://example.com\x07https://example.com\x1b]8;;\x07",
+            stack: "\x1b[33mError: fail\x1b[0m\n    at \x1b[36mfoo\x1b[0m (main.ts:10)",
+        }
+
+        const result = format_log_line(entry)
+
+        expect(result).toContain("boom plain")
+        expect(result).toContain("(https://example.com)")
+        expect(result).toContain("Error: fail")
+        expect(result).toContain("at foo")
+        expect(result).not.toContain("\x1b[")
+        expect(result).not.toContain("\x1b]")
+    })
 })

--- a/tests/next-plugin/handler.test.ts
+++ b/tests/next-plugin/handler.test.ts
@@ -91,6 +91,34 @@ describe("Next.js handler", () => {
 
             expect(response.status).toBe(204)
         })
+
+        it("strips ANSI escape codes before writing app router logs", async () => {
+            const entries = [
+                {
+                    level: "error",
+                    args: ["\x1b[31mboom\x1b[0m"],
+                    timestamp: "10:00:00.000",
+                    url: "\x1b]8;;https://example.com\x07https://example.com\x1b]8;;\x07",
+                    stack: "\x1b[33mError: fail\x1b[0m\n    at \x1b[36mrender\x1b[0m (app.ts:1)",
+                },
+            ]
+            const request = new Request("http://localhost/api/browser-logs", {
+                method: "POST",
+                body: JSON.stringify(entries),
+                headers: { "Content-Type": "application/json" },
+            })
+
+            const response = await POST(request)
+
+            expect(response.status).toBe(204)
+            const content = fs.readFileSync(log_file, "utf-8")
+            expect(content).toContain("boom")
+            expect(content).toContain("https://example.com")
+            expect(content).toContain("Error: fail")
+            expect(content).toContain("at render")
+            expect(content).not.toContain("\x1b[")
+            expect(content).not.toContain("\x1b]")
+        })
     })
 
     describe("pages_handler (Pages Router)", () => {
@@ -148,6 +176,28 @@ describe("Next.js handler", () => {
 
             const content = fs.readFileSync(log_file, "utf-8")
             expect(content).toContain("parsed")
+        })
+
+        it("strips ANSI escape codes before writing pages router logs", () => {
+            const entries = [
+                {
+                    level: "warn",
+                    args: ["\x1b[33mwarning\x1b[0m"],
+                    timestamp: "10:00:00.000",
+                    stack: "\x1b[31mError\x1b[0m\n    at \x1b[36mhandler\x1b[0m (page.ts:2)",
+                },
+            ]
+            const req = { method: "POST", body: entries }
+            const end_fn = vi.fn()
+            const res = { status: vi.fn(() => ({ end: end_fn })) }
+
+            pages_handler(req, res)
+
+            const content = fs.readFileSync(log_file, "utf-8")
+            expect(content).toContain("warning")
+            expect(content).toContain("Error")
+            expect(content).toContain("at handler")
+            expect(content).not.toContain("\x1b[")
         })
     })
 })

--- a/tests/vite-plugin/plugin.test.ts
+++ b/tests/vite-plugin/plugin.test.ts
@@ -185,6 +185,52 @@ describe("agentTail vite plugin", () => {
         expect(content).not.toContain("noisy message")
     })
 
+    it("strips ANSI escape codes before writing browser logs", () => {
+        const plugin = agentTail()
+        let handler: Function = () => {}
+        const mock_server = {
+            config: { root: temp_dir },
+            middlewares: {
+                use: (_p: string, h: Function) => {
+                    handler = h
+                },
+            },
+        }
+
+        vi.spyOn(console, "log").mockImplementation(() => {})
+        ;(plugin as any).configureServer(mock_server)
+
+        const log_entries = [
+            {
+                level: "error",
+                args: ["\x1b[31mbrowser boom\x1b[0m"],
+                timestamp: "10:30:00.123",
+                url: "\x1b]8;;https://example.com\x07https://example.com\x1b]8;;\x07",
+                stack: "\x1b[33mError: fail\x1b[0m\n    at \x1b[36mrender\x1b[0m (app.ts:1)",
+            },
+        ]
+
+        const req = new EventEmitter() as any
+        req.method = "POST"
+        const res = { writeHead: vi.fn(), end: vi.fn() }
+
+        handler(req, res)
+        req.emit("data", Buffer.from(JSON.stringify(log_entries)))
+        req.emit("end")
+
+        const log_dir = path.join(temp_dir, "tmp/logs")
+        const latest = path.join(log_dir, "latest")
+        const log_file = path.join(fs.realpathSync(latest), "browser.log")
+        const content = fs.readFileSync(log_file, "utf-8")
+
+        expect(content).toContain("browser boom")
+        expect(content).toContain("https://example.com")
+        expect(content).toContain("Error: fail")
+        expect(content).toContain("at render")
+        expect(content).not.toContain("\x1b[")
+        expect(content).not.toContain("\x1b]")
+    })
+
     it("joins an existing session from AGENT_TAIL_SESSION env var", () => {
         const session_dir = path.join(temp_dir, "tmp/logs/existing-session")
         fs.mkdirSync(session_dir, { recursive: true })


### PR DESCRIPTION
This makes ANSI handling consistent across agent-tail: live terminal output keeps child-process colors, while anything written to disk is stripped to plain text. That now applies to `wrap`, `run`, and the browser log pipelines used by the Vite and Next.js plugins.

Fixes #9

**What does this PR do?**
- preserves child-process ANSI styling in interactive terminal output for `wrap` and `run`
- strips ANSI escape codes before writing service logs, `combined.log`, and browser logs
- centralizes ANSI stripping in a shared core helper used by CLI and plugin formatting
- covers stdout, stderr, and ANSI-colored exclude filtering in CLI tests
- covers Vite, Next App Router, and Next Pages Router browser log writes

**How did you verify your code works?**
- [x] `pnpm run build`
- [x] `pnpm run test`
- [x] `pnpm run typecheck`
- [x] manual `wrap` verification with colored terminal output and plain log files
- [x] manual `run` verification with colored terminal output and plain log files

**Notes**
- I reviewed the common npm options (`strip-ansi` and `ansi-regex`) and did not add them here. The local helper already covers the escape sequences needed for this fix, keeps the runtime dependency surface smaller, and is now backed by regression tests across the CLI and plugin log paths.

**Demo**
Before:
<img width="2220" height="312" alt="CleanShot 2026-03-07 at 20 28 05@2x" src="https://github.com/user-attachments/assets/00ec02ce-eef7-40ba-9144-cbe305f9cce8" />

After:
<img width="2360" height="352" alt="CleanShot 2026-03-07 at 20 27 14@2x" src="https://github.com/user-attachments/assets/daa33d9b-5c1f-4a5e-82b8-f64da5211240" />